### PR TITLE
Bump version to 0.1.4 and clean old builds

### DIFF
--- a/.github/workflows/publish-multiplexer.yml
+++ b/.github/workflows/publish-multiplexer.yml
@@ -27,6 +27,10 @@ jobs:
       - name: 🔧 Install build tool
         run: python -m pip install --upgrade build
 
+      # Delete previous builds and distribution folders to avoid conflicts during packaging
+      - name: Clean previous builds
+        run: rm -rf dist/ build/ 
+
       - name: 🏗️ Build package
         run: python -m build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "multiplexer-llm"
-version = "0.1.3"
+version = "0.1.4"
 description = "A multiplexer for Large Language Model APIs built on the OpenAI SDK. It combines quotas from multiple models and automatically uses fallback models when the primary models are rate limited."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
This PR bumps version of multiplexer-llm to 0.1.4 in `pyproject.toml`  and Adds a cleanup step in `publish-multiplexer.yml` to delete any previous dist/ and build/ folders before building a new release. This ensures clean packaging and avoids stale artifacts.